### PR TITLE
Allow passing in instrumentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ build({
 
 This packages for Node automatically loads instrumentations for Node builtin modules and common packages.
 
-Enable auto instrumentation by configuring it in your esbuild script:
+Enable instrumentation by configuring it in your esbuild script:
 
 ```javascript
 const { openTelemetryPlugin } = require('opentelemetry-esbuild-plugin-node');
 const { build } = require('esbuild');
+const {
+  getNodeAutoInstrumentations,
+} = require('@opentelemetry/auto-instrumentations-node');
 
 build({
   entryPoints: ['src/server.ts'],
@@ -59,11 +62,13 @@ build({
   target: 'node20',
   platform: 'node',
   sourcemap: true,
-  plugins: [openTelemetryPlugin()],
+  plugins: [
+    openTelemetryPlugin({ instrumentations: getNodeAutoInstrumentations() }),
+  ],
 });
 ```
 
-Custom configuration for each of the instrumentations can be passed to the plugin, by providing an object with the name of the instrumentation as a key, and its configuration as the value.
+Custom configuration for each of the instrumentations can be passed to the plugin, by providing an object with the name of the instrumentation as a key, and its configuration as the value. Though passing instrumentations in directly is preferred, and the ability to configure via `instrumentationConfig` rather than passing in instrumentations directly will be removed in a future version.
 
 ```javascript
 const { openTelemetryPlugin } = require('opentelemetry-esbuild-plugin-node');

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { otelPackageToInstrumentationConfig } from './main';
+export { getOtelPackageToInstrumentationConfig } from './main';

--- a/test/test-app/build-manual-instrumentations.ts
+++ b/test/test-app/build-manual-instrumentations.ts
@@ -16,6 +16,7 @@
 
 import { build } from 'esbuild';
 import { openTelemetryPlugin } from '../../src/plugin';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 
 build({
   entryPoints: [`${__dirname}/app.ts`],
@@ -26,7 +27,7 @@ build({
   sourcemap: true,
   plugins: [
     openTelemetryPlugin({
-      instrumentationConfig: {
+      instrumentations: getNodeAutoInstrumentations({
         '@opentelemetry/instrumentation-pino': {
           logKeys: {
             traceId: 'traceId',
@@ -34,7 +35,7 @@ build({
             traceFlags: 'traceFlags',
           },
         },
-      },
+      }),
     }),
   ],
 }).catch(err => {


### PR DESCRIPTION
Allow passing in instrumentations directly, rather than configuring what is passed to `getNodeAutoInstrumentations`.